### PR TITLE
[🎨Style/23] Badge, Card variants 및 theme 테마 스타일 추가

### DIFF
--- a/src/app/styles/theme.css
+++ b/src/app/styles/theme.css
@@ -16,6 +16,7 @@
   --orange-50: #fff5f4;
   --orange-100: #ffdad5;
   --orange-500: #ff5e48;
+  --orange-700: #d82810;
 
   /* Blue */
   --blue-500: #00c8ff;
@@ -65,6 +66,7 @@
   --color-orange-50: var(--orange-50);
   --color-orange-100: var(--orange-100);
   --color-orange-500: var(--orange-500);
+  --color-orange-700: var(--orange-700);
 
   /* Blue */
   --color-blue-500: var(--blue-500);

--- a/src/components/ui/Badge/Badge.variants.ts
+++ b/src/components/ui/Badge/Badge.variants.ts
@@ -14,6 +14,7 @@ export const BadgeVariants = cva(
         white: 'bg-white text-orange-500',
         orange: 'bg-orange-500 text-white',
         blue: 'bg-blue-500 text-white',
+        darkOrange: 'bg-orange-700 text-white',
       },
     },
     defaultVariants: {

--- a/src/components/ui/Cards/Card.variants.ts
+++ b/src/components/ui/Cards/Card.variants.ts
@@ -1,6 +1,6 @@
 import { cva } from 'class-variance-authority'
 
-export const CardVariant = cva('flex w-full rounded-lg p-16', {
+export const CardVariant = cva('flex w-full rounded-lg p-12', {
   variants: {
     theme: {
       dark: 'bg-gray-800 text-white',


### PR DESCRIPTION
## 작업 내용

<!-- 어떤 작업인지 간단히 설명 -->
- Badge, Card variants 및 theme 테마 스타일 추가

## 변경 사항

- [x] Badge.variants.ts 배지 테마 스타일 추가
- [x] Card.variants.ts 카드 테마 스타일 추가
- [x] theme.css 글로벌 테마 스타일 추가


## 스크린샷

<!-- 변경된 UI 있으면 첨부 -->

## 관련 이슈

<!-- closes #이슈번호 -->
#44 