### PR TITLE
[♻️Refactor/48] MainPage 및 HomeCardSection의 FadeIn 애니메이션 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,21 @@
 import HomeTitleSection from '@/components/sections/Home/HomeTitleSection'
 import HomeCardSection from '@/components/sections/Home/HomeCardSection'
-// MainPage
 import HomeContact from '@/components/sections/Home/HomeContact'
 import Section from '@/components/ui/Section'
+import FadeIn from '@/components/ui/FadeIn'
 
 export default function MainPage() {
   return (
     <Section inner='50'>
       <div className='flex items-start justify-between gap-8'>
-        <HomeTitleSection />
-        <HomeContact />
+        <FadeIn>
+          <HomeTitleSection />
+        </FadeIn>
+        <FadeIn delay={0.2}>
+          <HomeContact />
+        </FadeIn>
       </div>
+
       <HomeCardSection />
     </Section>
   )

--- a/src/components/sections/Home/HomeCardSection.tsx
+++ b/src/components/sections/Home/HomeCardSection.tsx
@@ -1,20 +1,24 @@
 import ProjectCard from '@/components/ui/Cards/ProjectCard'
 import { HomeHeros } from '@/data/projects/home'
 import TypingIndicator from '@/components/ui/Cards/TypingIndicator'
+import FadeIn from '@/components/ui/FadeIn'
 
 export default function HomeCardSection() {
   return (
     <div className='flex items-stretch justify-center gap-8 pt-24'>
-      {HomeHeros.cards.map((card) => (
-        <ProjectCard
-          key={card.title}
-          className='w-75 shrink-0'
-          title={card.title}
-          description={card.description}
-          button={card.button}
-          theme={card.theme}
-          titleSlot={card.title === '나래봇' ? <TypingIndicator /> : undefined}
-        />
+      {HomeHeros.cards.map((card, i) => (
+        <FadeIn key={card.title} delay={0.3 + i * 0.15}>
+          <ProjectCard
+            className='h-full w-75 shrink-0'
+            title={card.title}
+            description={card.description}
+            button={card.button}
+            theme={card.theme}
+            titleSlot={
+              card.title === '나래봇' ? <TypingIndicator /> : undefined
+            }
+          />
+        </FadeIn>
       ))}
     </div>
   )

--- a/src/components/ui/Cards/ProjectCard.tsx
+++ b/src/components/ui/Cards/ProjectCard.tsx
@@ -41,13 +41,13 @@ export default function ProjectCard({
             </Text>
             {titleSlot}
           </div>
-          <Text as='body' className='pt-4'>
+          <Text as='p' className='pt-4'>
             {description}
           </Text>
           {children}
         </div>
         {button && (
-          <div className='mt-16 flex h-15 w-full items-center justify-center rounded-full bg-white text-xl font-semibold text-gray-900'>
+          <div className='mt-16 flex h-15 w-full items-center justify-center rounded-full bg-white text-lg font-semibold text-gray-900'>
             {button.label}
           </div>
         )}


### PR DESCRIPTION
## 작업 내용

메인 페이지 FadeIn 스크롤 애니메이션 적용

## 변경 사항

- [x] MainPage 섹션별 FadeIn 적용 (타이틀, Contact, 카드)
- [x] HomeCardSection 카드 순차 등장 (0.15초 간격)

## 변경 타입

- [ ] feat (새 기능)
- [ ] fix (버그 수정)
- [ ] chore (설정 변경)
- [x] refactor (리팩토링)

## 스크린샷

<!-- 메인 페이지 애니메이션 GIF 첨부 -->

## 관련 이슈

closes #48

## ClickUp 태스크

<!-- CLICKUP: https://app.clickup.com/t/태스크ID -->

## 셀프 체크리스트

- [x] 코드 동작 확인
- [x] 콘솔 에러 없음
- [ ] ClickUp URL 입력 완료