### PR TITLE
[♻️Refactor/52] SmolsResultSection 및 FeatureCard 컴포넌트 스타일 수정 및 데이터 업데이트

### DIFF
--- a/src/components/sections/Smols/SmolsResultSection.tsx
+++ b/src/components/sections/Smols/SmolsResultSection.tsx
@@ -8,8 +8,13 @@ type ResultItem = ProductResult['items'][number]
 
 export default function SmolsResultSection() {
   return (
-    <Section className='bg-orange-500'>
-      <SectionHeader {...smols.sections.resultSection}></SectionHeader>
+    <Section className='bg-gray-900'>
+      <SectionHeader
+        badgeTheme='orange'
+        className='text-white'
+        titleSize='h4'
+        {...smols.sections.resultSection}
+      ></SectionHeader>
 
       <div className='grid grid-cols-3 gap-8 pt-16'>
         {smols.result.items.map((item: ResultItem, index: number) => (
@@ -18,7 +23,7 @@ export default function SmolsResultSection() {
             emoji={item.emoji}
             title={item.title}
             description={item.description}
-            theme='lightOrange'
+            theme='dark'
           />
         ))}
       </div>

--- a/src/components/sections/Smols/SmolsResultSection.tsx
+++ b/src/components/sections/Smols/SmolsResultSection.tsx
@@ -1,5 +1,6 @@
 import FeatureCard from '@/components/ui/Cards/FeatureCard'
 import SectionHeader from '@/components/ui/SectionHeader/SectionHeader'
+import FadeIn from '@/components/ui/FadeIn'
 import { smols } from '@/data/projects'
 import Section from '@/components/ui/Section'
 import type { ProductResult } from '@/data/types/smols'
@@ -9,22 +10,25 @@ type ResultItem = ProductResult['items'][number]
 export default function SmolsResultSection() {
   return (
     <Section className='bg-gray-900'>
-      <SectionHeader
-        badgeTheme='orange'
-        className='text-white'
-        titleSize='h4'
-        {...smols.sections.resultSection}
-      />
+      <FadeIn>
+        <SectionHeader
+          badgeTheme='orange'
+          className='text-white'
+          titleSize='h4'
+          {...smols.sections.resultSection}
+        />
+      </FadeIn>
 
       <div className='grid grid-cols-3 gap-8 pt-16'>
         {smols.result.items.map((item: ResultItem, index: number) => (
-          <FeatureCard
-            key={index}
-            value={item.value}
-            title={item.title}
-            description={item.description}
-            theme='dark'
-          />
+          <FadeIn key={index} delay={0.2 + index * 0.15}>
+            <FeatureCard
+              value={item.value}
+              title={item.title}
+              description={item.description}
+              theme='dark'
+            />
+          </FadeIn>
         ))}
       </div>
     </Section>

--- a/src/components/sections/Smols/SmolsResultSection.tsx
+++ b/src/components/sections/Smols/SmolsResultSection.tsx
@@ -14,13 +14,13 @@ export default function SmolsResultSection() {
         className='text-white'
         titleSize='h4'
         {...smols.sections.resultSection}
-      ></SectionHeader>
+      />
 
       <div className='grid grid-cols-3 gap-8 pt-16'>
         {smols.result.items.map((item: ResultItem, index: number) => (
           <FeatureCard
             key={index}
-            emoji={item.emoji}
+            value={item.value}
             title={item.title}
             description={item.description}
             theme='dark'

--- a/src/components/ui/Cards/FeatureCard.tsx
+++ b/src/components/ui/Cards/FeatureCard.tsx
@@ -9,9 +9,6 @@ type FeatureCardProps = {
   emoji: string
 } & VariantProps<typeof CardVariant>
 
-const emojiStyle =
-  'flex h-24 w-24 items-center justify-center rounded-full border border-orange-100 bg-white text-center text-5xl mx-auto'
-
 export default function FeatureCard({
   title,
   description,
@@ -27,15 +24,17 @@ export default function FeatureCard({
         'flex flex-col items-center text-center'
       )}
     >
-      <span className={cn(emojiStyle, 'text-2xl font-bold text-orange-500')}>
+      <Text as='h4' className='text-5xl font-bold text-orange-500'>
         {emoji}
-      </span>
-      <Text as='h6' className='mt-5 font-bold'>
+      </Text>
+
+      <Text as='body' className='mt-8 font-medium'>
         {title}
       </Text>
-      <div className='mt-3'>
+
+      <div className='mt-1'>
         {descriptions.map((desc, index) => (
-          <Text as='p' key={index}>
+          <Text as='p' key={index} className='pt-1 text-gray-400'>
             {desc}
           </Text>
         ))}

--- a/src/components/ui/Cards/FeatureCard.tsx
+++ b/src/components/ui/Cards/FeatureCard.tsx
@@ -6,13 +6,13 @@ import { cn } from '@/lib/cn'
 type FeatureCardProps = {
   title: string
   description: string | string[]
-  emoji: string
+  value: string
 } & VariantProps<typeof CardVariant>
 
 export default function FeatureCard({
   title,
   description,
-  emoji,
+  value,
   theme,
 }: FeatureCardProps) {
   const descriptions = Array.isArray(description) ? description : [description]
@@ -24,11 +24,11 @@ export default function FeatureCard({
         'flex flex-col items-center text-center'
       )}
     >
-      <Text as='h4' className='text-5xl font-bold text-orange-500'>
-        {emoji}
+      <Text as='body' className='text-4xl font-bold text-orange-500'>
+        {value}
       </Text>
 
-      <Text as='body' className='mt-8 font-medium'>
+      <Text as='body' className='mt-6 font-medium'>
         {title}
       </Text>
 

--- a/src/data/projects/smols/result.ts
+++ b/src/data/projects/smols/result.ts
@@ -3,17 +3,17 @@ import type { ProductResult } from '@/data/types/smols'
 export const smolsResult: ProductResult = {
   items: [
     {
-      emoji: '15% → 32%',
+      value: '15% → 32%',
       title: '기록 전환율',
       description: ['기록 진입 구조 개선 후'],
     },
     {
-      emoji: '941건',
+      value: '941건',
       title: '리뷰 분석',
       description: ['Pain Point 도출 기반'],
     },
     {
-      emoji: '3단계 → 1단계',
+      value: '3단계 → 1단계',
       title: '행동 단계 수정',
       description: ['메인에서 기록 진입까지 CTA 최소화'],
     },

--- a/src/data/projects/smols/result.ts
+++ b/src/data/projects/smols/result.ts
@@ -3,19 +3,19 @@ import type { ProductResult } from '@/data/types/smols'
 export const smolsResult: ProductResult = {
   items: [
     {
-      emoji: '↑32%',
+      emoji: '15% → 32%',
       title: '기록 전환율',
-      description: ['탐색 → 기록 진입 증가'],
+      description: ['기록 진입 구조 개선 후'],
     },
     {
-      emoji: '+28%',
-      title: '재방문율',
-      description: ['꾸미기 경험 반복 유도'],
+      emoji: '941건',
+      title: '리뷰 분석',
+      description: ['Pain Point 도출 기반'],
     },
     {
-      emoji: '↑21%',
-      title: '기록 완료율',
-      description: ['최소 입력 구조 효과'],
+      emoji: '3단계 → 1단계',
+      title: '행동 단계 수정',
+      description: ['메인에서 기록 진입까지 CTA 최소화'],
     },
   ],
 }

--- a/src/data/projects/smols/sections.ts
+++ b/src/data/projects/smols/sections.ts
@@ -71,8 +71,8 @@ export const smolsSections: Record<string, SectionData> = {
 
   resultSection: {
     type: 'result',
-    badge: 'RESULT',
-    title: 'UX 개선 기대 결과',
+    badge: '회고',
+    title: '구조를 바꾸자 사람이 \n기록하기 시작했다',
     description: '',
     align: 'center',
   },

--- a/src/data/types/smols/result.types.ts
+++ b/src/data/types/smols/result.types.ts
@@ -1,6 +1,6 @@
 export type ProductResult = {
   items: {
-    emoji: string
+    value: string
     title: string
     description: string[]
   }[]


### PR DESCRIPTION
## 작업 내용
SmolsResultSection과 FeatureCard의 시각 구조를 개선했습니다.
기존 알약(pill) 형태의 배지 스타일을 제거하고, 지표 텍스트를 타이포그래피 중심으로 강조하도록 변경했습니다. 회고 섹션의 디스크립션 데이터도 핵심 메시지 중심으로 간결하게 정리했습니다.

## 변경 사항
- [x] FeatureCard에서 pill 스타일 제거 및 타이포그래피 기반 강조 방식으로 변경
- [x] SmolsResultSection의 SectionHeader에서 중복된 `align` prop 제거
- [x] smols 프로젝트의 result 데이터 및 sections 데이터 문구 업데이트
- [x] 회고 섹션 본문 및 카드 디스크립션 간결화

## 변경 타입
- [ ] feat (새 기능)
- [ ] fix (버그 수정)
- [ ] chore (설정 변경)
- [x] refactor (리팩토링)

## 스크린샷
| Before | After |
| --- | --- |
| (기존 pill 배지 버전 스크린샷) | (타이포그래피 강조 버전 스크린샷) |

## 관련 이슈
closes #52

## ClickUp 태스크
<!-- CLICKUP: https://app.clickup.com/t/태스크ID -->

## 셀프 체크리스트
- [x] 코드 동작 확인
- [x] 콘솔 에러 없음
- [x] TypeScript 에러