### PR TITLE
[✨Feature/54] 블로그 섹션 추가 및 관련 데이터 업데이트

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'github.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'jerryko570.github.io',
+      },
     ],
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fast-xml-parser": "^5.7.1",
         "framer-motion": "^12.38.0",
+        "gray-matter": "^4.0.3",
         "motion": "^12.38.0",
         "next": "16.1.6",
         "papaparse": "^5.5.3",
@@ -1565,6 +1567,18 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4304,6 +4318,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -4356,6 +4383,18 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4431,6 +4470,42 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -4799,6 +4874,43 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5162,6 +5274,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -5594,6 +5715,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -6651,6 +6781,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -7207,6 +7352,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -7491,6 +7649,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -7686,6 +7850,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7698,6 +7871,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fast-xml-parser": "^5.7.1",
     "framer-motion": "^12.38.0",
+    "gray-matter": "^4.0.3",
     "motion": "^12.38.0",
     "next": "16.1.6",
     "papaparse": "^5.5.3",

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,7 @@
 import AboutHeroSection from '@/components/sections/About/AboutHeroSection'
 import AboutStrengthSection from '@/components/sections/About/AboutStrengthSection'
 import AboutCareerSection from '@/components/sections/About/AboutCareerSection'
+import AboutBlogSection from '@/components/sections/About/AboutBlogSection'
 import AboutBotSection from '@/components/sections/About/AboutBotSection'
 
 export default function AboutPage() {
@@ -9,6 +10,7 @@ export default function AboutPage() {
       <AboutHeroSection />
       <AboutStrengthSection />
       <AboutCareerSection />
+      <AboutBlogSection />
       <AboutBotSection />
     </div>
   )

--- a/src/app/styles/theme.css
+++ b/src/app/styles/theme.css
@@ -24,6 +24,7 @@
   /* Blue */
   --blue-100: #fcfdff;
   --blue-200: #f4f7ff;
+  --blue-300: #e7edff;
   --blue-400: #5f8aff;
   --blue-500: #4576fc;
   --blue-600: #2355de;
@@ -99,6 +100,7 @@
   /* Blue */
   --color-blue-100: var(--blue-100);
   --color-blue-200: var(--blue-200);
+  --color-blue-300: var(--blue-300);
   --color-blue-500: var(--blue-500);
   --color-blue-600: var(--blue-600);
   --color-blue-700: var(--blue-700);

--- a/src/components/sections/About/AboutBlogSection.tsx
+++ b/src/components/sections/About/AboutBlogSection.tsx
@@ -1,0 +1,87 @@
+import Section from '@/components/ui/Section'
+import Text from '@/components/ui/Text/Text'
+import Button from '@/components/ui/Button/Button'
+import FadeIn from '@/components/ui/FadeIn'
+import Link from 'next/link'
+import Image from 'next/image'
+import { aboutBlog } from '@/data/projects/about'
+import { getBlogPosts } from '@/lib/getBlogPosts'
+
+export default async function AboutBlogSection() {
+  const posts = await getBlogPosts(2)
+
+  return (
+    <Section className='bg-blue-500'>
+      <div className='flex items-center justify-between gap-16'>
+        {/* 왼쪽 — 타이틀과 CTA */}
+        <FadeIn>
+          <div className='max-w-xl'>
+            <Text as='h4' className='mb-4 font-bold text-white'>
+              {aboutBlog.title}
+            </Text>
+            <Text as='p' className='mb-8 whitespace-pre-line text-white'>
+              {aboutBlog.description}
+            </Text>
+            <div className='pt-4'>
+              <Link
+                href='https://jerryko570.github.io/'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                <Button
+                  variant='white'
+                  label={aboutBlog.cta}
+                  size='lg'
+                  className='hover:bg-gray-200'
+                />
+              </Link>
+            </div>
+          </div>
+        </FadeIn>
+
+        {/* 오른쪽 — 블로그 카드 2개 가로 배치 */}
+        <div className='grid w-140 grid-cols-2 gap-6'>
+          {posts.map((post, i) => (
+            <FadeIn key={post.slug} delay={0.3 + i * 0.1}>
+              <Link
+                href={post.url}
+                target='_blank'
+                rel='noopener noreferrer'
+                className='group flex h-full flex-col overflow-hidden rounded-2xl bg-white transition-all duration-300 hover:-translate-y-1'
+              >
+                {/* 썸네일 — 정사각형 */}
+                {post.thumbnail && (
+                  <div className='relative h-30 w-full shrink-0 overflow-hidden bg-gray-900'>
+                    <Image
+                      src={post.thumbnail}
+                      alt={post.title}
+                      fill
+                      sizes='240px'
+                      className='object-cover transition-transform duration-500 group-hover:scale-105'
+                    />
+                  </div>
+                )}
+
+                {/* 텍스트 영역 */}
+                <div className='flex flex-1 flex-col p-4'>
+                  <Text
+                    as='p'
+                    className='line-clamp-3 block font-medium text-gray-900'
+                  >
+                    {post.title}
+                  </Text>
+                  <Text
+                    as='caption'
+                    className='block pt-2 font-extralight text-gray-400'
+                  >
+                    {post.categories[0] || post.tags[0] || 'Blog'} · {post.date}
+                  </Text>
+                </div>
+              </Link>
+            </FadeIn>
+          ))}
+        </div>
+      </div>
+    </Section>
+  )
+}

--- a/src/components/sections/About/AboutBotSection.tsx
+++ b/src/components/sections/About/AboutBotSection.tsx
@@ -31,7 +31,7 @@ export default function AboutBotSection() {
         </FadeIn>
 
         {/* 오른쪽 — 구현 스택 */}
-        <div className='grid w-114 grid-cols-2 gap-4'>
+        <div className='grid w-142 grid-cols-2 gap-4'>
           {aboutBot.features.map((feature, i) => (
             <FadeIn key={feature.label} delay={0.2 + i * 0.1}>
               <div className='h rounded-xl bg-gray-800 p-4 transition-all duration-300 hover:-translate-y-1 hover:bg-gray-700'>

--- a/src/components/sections/About/AboutCareerSection.tsx
+++ b/src/components/sections/About/AboutCareerSection.tsx
@@ -14,7 +14,7 @@ const eraGapClassMap = {
 
 export default function AboutCareerSection() {
   return (
-    <Section className='-mt-8 bg-blue-200'>
+    <Section className='-mt-24 bg-blue-200'>
       <div className='grid grid-cols-2 gap-20'>
         {/* 왼쪽 — Career */}
         <div>
@@ -104,8 +104,8 @@ export default function AboutCareerSection() {
                 )}
               </ul>
 
-              <div className='mt-10 rounded-2xl bg-blue-500 p-6 text-center'>
-                <Text as='p' className='font-medium text-white'>
+              <div className='mt-10 rounded-2xl border border-blue-500 bg-blue-300 p-6 text-center'>
+                <Text as='p' className='font-medium text-blue-500'>
                   {aboutCareer.closing}
                 </Text>
               </div>

--- a/src/components/sections/About/AboutHeroSection.tsx
+++ b/src/components/sections/About/AboutHeroSection.tsx
@@ -7,7 +7,7 @@ import { aboutHero } from '@/data/projects/about'
 
 export default function AboutHeroSection() {
   return (
-    <Section inner='50' className='bg-white'>
+    <Section className='bg-white'>
       <div className='flex items-start justify-between'>
         {/* 왼쪽 — 타이틀 + 설명 */}
         <FadeIn>

--- a/src/data/projects/about/about.ts
+++ b/src/data/projects/about/about.ts
@@ -38,6 +38,20 @@ export const aboutStrengths = [
   },
 ] as const
 
+export const aboutBlog = {
+  badge: 'AI IMPLEMENTATION',
+  title: '✏️ 3일마다 쌓이는 학습 파이프라인',
+  description:
+    '디자인·개발·AI는 매일 새로운 게 쏟아집니다.\n3일마다 최신 소식을 자동 수집하고 블로그로 \n기록되도록 구축했습니다.',
+  cta: '깃 블로그 구경가기',
+  features: [
+    { label: 'Claude API', desc: 'AI 답변 생성 엔진' },
+    { label: 'Next.js API Route', desc: '서버 통신 직접 구현' },
+    { label: 'Streaming', desc: '실시간 타이핑 효과' },
+    { label: '지식베이스', desc: '포트폴리오 내용을 AI에 학습' },
+  ],
+}
+
 export const aboutBot = {
   badge: 'AI IMPLEMENTATION',
   title: '🤖 나래봇 포트폴리오 AI 어시스턴트',

--- a/src/lib/getBlogPosts.ts
+++ b/src/lib/getBlogPosts.ts
@@ -1,0 +1,142 @@
+// src/lib/getBlogPosts.ts
+import matter from 'gray-matter'
+
+const GITHUB_OWNER = 'jerryko570'
+const GITHUB_REPO = 'jerryko570.github.io'
+const POSTS_PATH = '_posts'
+const BLOG_BASE_URL = 'https://jerryko570.github.io'
+
+export type BlogPost = {
+  slug: string
+  title: string
+  description: string
+  date: string
+  categories: string[]
+  tags: string[]
+  thumbnail: string | null
+  url: string
+}
+
+type GitHubFile = {
+  name: string
+  path: string
+  sha: string
+  download_url: string
+  type: 'file' | 'dir'
+}
+
+export async function getBlogPosts(limit: number = 3): Promise<BlogPost[]> {
+  try {
+    const listRes = await fetch(
+      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${POSTS_PATH}`,
+      {
+        headers: {
+          Accept: 'application/vnd.github.v3+json',
+          ...(process.env.GITHUB_TOKEN && {
+            Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          }),
+        },
+        next: { revalidate: 3600 },
+      }
+    )
+
+    if (!listRes.ok) {
+      throw new Error(`GitHub API error: ${listRes.status}`)
+    }
+
+    const files: GitHubFile[] = await listRes.json()
+
+    const markdownFiles = files
+      .filter((f) => f.type === 'file' && f.name.endsWith('.md'))
+      .sort((a, b) => b.name.localeCompare(a.name))
+      .slice(0, limit)
+
+    const posts = await Promise.all(
+      markdownFiles.map(async (file) => {
+        const contentRes = await fetch(file.download_url, {
+          next: { revalidate: 3600 },
+        })
+        const rawContent = await contentRes.text()
+        const { data, content } = matter(rawContent)
+
+        const slug = file.name
+          .replace(/^\d{4}-\d{2}-\d{2}-/, '')
+          .replace(/\.md$/, '')
+
+        return {
+          slug,
+          title: data.title || '',
+          description: data.description || extractDescription(content),
+          date: formatDate(data.date || extractDateFromFilename(file.name)),
+          categories: Array.isArray(data.categories) ? data.categories : [],
+          tags: Array.isArray(data.tags) ? data.tags : [],
+          thumbnail: extractThumbnail(data), // ← 추가
+          url: `${BLOG_BASE_URL}/posts/${slug}/`,
+        }
+      })
+    )
+
+    return posts
+  } catch (error) {
+    console.error('Error fetching blog posts:', error)
+    return []
+  }
+}
+
+// ============== 헬퍼 ==============
+
+/**
+ * Chirpy 테마의 Front Matter에서 썸네일 경로 추출
+ * 여러 가능한 필드명을 순서대로 확인
+ */
+function extractThumbnail(data: Record<string, unknown>): string | null {
+  // Chirpy 기본: image.path
+  if (data.image && typeof data.image === 'object') {
+    const img = data.image as { path?: string; src?: string }
+    if (img.path) return normalizeImageUrl(img.path)
+    if (img.src) return normalizeImageUrl(img.src)
+  }
+
+  // 기타 가능한 필드명
+  if (typeof data.image === 'string') return normalizeImageUrl(data.image)
+  if (typeof data.thumbnail === 'string')
+    return normalizeImageUrl(data.thumbnail)
+  if (typeof data.cover === 'string') return normalizeImageUrl(data.cover)
+
+  return null
+}
+
+/**
+ * 상대 경로(/assets/img/...)를 블로그 절대 URL로 변환
+ */
+function normalizeImageUrl(path: string): string {
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path
+  }
+  // 상대 경로면 블로그 도메인 붙임
+  return `${BLOG_BASE_URL}${path.startsWith('/') ? '' : '/'}${path}`
+}
+
+function extractDescription(content: string): string {
+  const text = content
+    .replace(/^#.*/gm, '')
+    .replace(/!\[.*?\]\(.*?\)/g, '')
+    .replace(/\[(.*?)\]\(.*?\)/g, '$1')
+    .trim()
+  return text.slice(0, 100).trim() + '...'
+}
+
+function extractDateFromFilename(filename: string): string {
+  const match = filename.match(/^(\d{4}-\d{2}-\d{2})/)
+  return match ? match[1] : ''
+}
+
+function formatDate(dateInput: string | Date): string {
+  const date = new Date(dateInput)
+  if (isNaN(date.getTime())) return ''
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}


### PR DESCRIPTION
## 작업 내용
About 페이지에 "3일마다 쌓이는 학습 파이프라인" 블로그 섹션을 추가했습니다.
GitHub API와 gray-matter를 활용해 개인 블로그(jerryko570.github.io)의 최신 글 2개를 자동으로 불러와 About 페이지에 노출되도록 구현했습니다. 블로그에 새 글이 올라오면 포트폴리오 페이지에도 1시간 내로 자동 반영됩니다.

## 변경 사항
- [x] AboutBlogSection 컴포넌트 신규 생성 (블로그 자동화 섹션)
- [x] GitHub API 기반 블로그 글 fetch 유틸(`getBlogPosts.ts`) 구현
- [x] `gray-matter` 패키지 추가로 Front Matter 파싱 지원
- [x] 블로그 도메인(`jerryko570.github.io`) Next.js 이미지 허용 목록 추가
- [x] `aboutBlog` 데이터 구조 추가 (타이틀, 설명, CTA)
- [x] About 페이지에 AboutBlogSection 연결
- [x] 다른 About 섹션(Bot, Career, Hero)의 레이아웃 및 스타일 미세 조정
- [x] 환경 변수 `GITHUB_TOKEN` 연동 (API rate limit 대응)

## 변경 타입
- [x] feat (새 기능)
- [ ] fix (버그 수정)
- [ ] chore (설정 변경)
- [ ] refactor (리팩토링)

## 스크린샷
| 블로그 섹션 |
| --- |
| (추가된 AboutBlogSection 스크린샷) |

## 관련 이슈
closes #106

## ClickUp 태스크
<!-- CLICKUP: https://app.clickup.com/t/태스크ID -->

## 셀프 체크리스트
- [x] 코드 동작 확인 (블로그 최신 글 2개 정상 노출)